### PR TITLE
add the meanq data to the load_baseline as well as the yaml for pkgdown

### DIFF
--- a/R/load_baseline_data.R
+++ b/R/load_baseline_data.R
@@ -105,6 +105,7 @@ load_baseline_data <- function(species) {
                      Dlt.inp = cvpiaData::misc_delta,
                      prop.pulse = cvpiaData::prop_pulse,
                      medQ = cvpiaData::med_flow, 
+                     meanQ = cvpiaData::meanQ,
                      aveT20 = cvpiaData::aveT20, 
                      aveT20D = cvpiaData::aveT20D, 
                      maxT24 = cvpiaData::maxT24, 

--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -32,6 +32,7 @@ reference:
   - total_diversion
   - prop_pulse
   - med_flow
+  - meanQ
 - title: Habitat Inputs
   contents:
   - dlt_hab


### PR DESCRIPTION
meanQ was not being exported by the load_baseline_data() function this commit fixes this issue. I also add it to the yaml for pkgdown.