### PR TITLE
add references to the new temps in the pkdown yaml

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -50,6 +50,10 @@ reference:
   - degday
   - ptemp20mc
   - egg_temp_effect
+  - aveT20
+  - aveT20D
+  - maxT24
+  - maxT29
 - title: Miscellaneous Inputs
   contents:
   - misc_data


### PR DESCRIPTION
I forgot I had to explicitly add new entries of documentation into this yaml, this commit fixes that.